### PR TITLE
feat: add miner validator interface

### DIFF
--- a/marketevent/market_event.go
+++ b/marketevent/market_event.go
@@ -31,11 +31,11 @@ type MarketEventStream struct {
 	connLk           sync.RWMutex
 	minerConnections map[address.Address]*channelStore
 	cfg              *types.Config
-	validator        *validator.AuthMinerValidator
+	validator        validator.IAuthMinerValidator
 	*types.BaseEventStream
 }
 
-func NewMarketEventStream(ctx context.Context, validator *validator.AuthMinerValidator, cfg *types.Config) *MarketEventStream {
+func NewMarketEventStream(ctx context.Context, validator validator.IAuthMinerValidator, cfg *types.Config) *MarketEventStream {
 	marketEventStream := &MarketEventStream{
 		connLk:           sync.RWMutex{},
 		minerConnections: make(map[address.Address]*channelStore),

--- a/proofevent/proof_event.go
+++ b/proofevent/proof_event.go
@@ -28,11 +28,11 @@ type ProofEventStream struct {
 	connLk           sync.RWMutex
 	minerConnections map[address.Address]*channelStore
 	cfg              *types.Config
-	validator        *validator.AuthMinerValidator
+	validator        validator.IAuthMinerValidator
 	*types.BaseEventStream
 }
 
-func NewProofEventStream(ctx context.Context, validator *validator.AuthMinerValidator, cfg *types.Config) *ProofEventStream {
+func NewProofEventStream(ctx context.Context, validator validator.IAuthMinerValidator, cfg *types.Config) *ProofEventStream {
 	proofEventStream := &ProofEventStream{
 		connLk:           sync.RWMutex{},
 		minerConnections: make(map[address.Address]*channelStore),

--- a/validator/miner_validator.go
+++ b/validator/miner_validator.go
@@ -15,6 +15,12 @@ type AuthMinerValidator struct {
 	authClient types.IAuthClient
 }
 
+type IAuthMinerValidator interface {
+	Validate(ctx context.Context, miner address.Address) error
+}
+
+var _ IAuthMinerValidator = (*AuthMinerValidator)(nil)
+
 func (amv *AuthMinerValidator) Validate(ctx context.Context, miner address.Address) error {
 	account, exist := jwtclient.CtxGetName(ctx)
 	if !exist {
@@ -34,6 +40,6 @@ func (amv *AuthMinerValidator) Validate(ctx context.Context, miner address.Addre
 	return nil
 }
 
-func NewMinerValidator(authClient types.IAuthClient) *AuthMinerValidator {
+func NewMinerValidator(authClient types.IAuthClient) IAuthMinerValidator {
 	return &AuthMinerValidator{authClient: authClient}
 }


### PR DESCRIPTION
add miner validator interface

增加接口的原因:
venua-market中调用了gateway的marketevent.NewMarketEventStream方法, 并且希望validator总是返回验证通过:
如果不修改为interface, 
venus-market没有办法修改原始逻辑导致验证失败:
```go
	func NewMarketEvent(mctx metrics.MetricsCtx) (*marketevent.MarketEventStream, error) {
	stream := marketevent.NewMarketEventStream(mctx, func(miner address.Address) (bool, error) {
		return true, nil
	}, &types3.Config{
		RequestQueueSize: 30,
		RequestTimeout:   time.Second * 30,
	})
	return stream, nil
}
```